### PR TITLE
Solucion del principio DIP Y OCP

### DIFF
--- a/Observaciones
+++ b/Observaciones
@@ -1,0 +1,11 @@
+Principio de abierto/cerrado (OCP): Este principio establece que las entidades de software
+ (clases, módulos, funciones, etc.) deben estar abiertas para la extensión, pero cerradas para 
+la modificación. En este caso, los métodos onInstall y onUpdate están diseñados para ser sobrescritos, 
+lo que podría violar el principio OCP si se necesita modificar la funcionalidad base en lugar de
+extenderla.
+
+
+2.Principio de abierto/cerrado (OCP): Este principio establece que las entidades de software 
+(clases, módulos, funciones, etc.) deben estar abiertas para la extensión, pero cerradas para
+ la modificación. En este caso, los métodos onInstall y onUpdate están diseñados para ser sobrescritos, 
+lo que podría violar el principio OCP si se necesita modificar la funcionalidad base en lugar de extenderla.

--- a/Observaciones2
+++ b/Observaciones2
@@ -1,0 +1,37 @@
+Para solucionar esta violación del DIP, podrías introducir una interfaz que ambas 
+clases implementen. Esto permitiría a FixedOdnoklassnikiApi depender de una abstracción
+ en lugar de una implementación concreta.
+
+
+public interface IOdnoklassnikiApi {
+    OdnoklassnikiOAuthService createService(String apiKey, String apiSecret, String callback,
+        String defaultScope, String responseType, String userAgent, 
+        HttpClientConfig httpClientConfig, HttpClient httpClient);
+}
+
+public class OdnoklassnikiApi implements IOdnoklassnikiApi {
+    // implementación existente
+}
+
+public class FixedOdnoklassnikiApi implements IOdnoklassnikiApi {
+    // implementación existente
+
+    private static class InstanceHolder {
+        private static final IOdnoklassnikiApi INSTANCE = new FixedOdnoklassnikiApi();
+    }
+
+    public static IOdnoklassnikiApi instance() {
+        return InstanceHolder.INSTANCE;
+    }
+
+    @Override
+    public OdnoklassnikiOAuthService createService(String apiKey, String apiSecret, String callback,
+         String defaultScope, String responseType, String userAgent, 
+        HttpClientConfig httpClientConfig, HttpClient httpClient) {
+        // implementación existente
+    }
+}
+En este ejemplo, tanto OdnoklassnikiApi como FixedOdnoklassnikiApi implementan la interfaz
+ IOdnoklassnikiApi. Esto significa que cualquier código que necesite usar una de estas clases 
+puede depender de la interfaz IOdnoklassnikiApi en lugar de una implementación concreta,
+ lo que está en línea con el DIP.


### PR DESCRIPTION
Para cumplir con el Principio de Abierto/Cerrado (OCP), podríamos introducir una interfaz o una clase abstracta que defina los métodos que deben ser implementados por cualquier módulo. De esta manera, cada módulo puede tener su propia implementación de estos métodos, permitiendo la extensión sin necesidad de modificar el código existente.

Aquí hay un ejemplo de cómo podríamos refactorizar el código para cumplir con el principio OCP:
public abstract class AbstractModule {
    protected abstract void onInstall(OrienteerWebApplication app, ODatabaseSession db);
    protected abstract void onUpdate(OrienteerWebApplication app, ODatabaseSession db, int oldVersion, int newVersion);
}

public class OPosterAppModule extends AbstractModule {
    public static final String NAME = "oposter-app";

    protected OPosterAppModule() {
        super(NAME, 1, OPosterModule.NAME);
    }

    @Override
    public void onInstall(OrienteerWebApplication app, ODatabaseSession db) {
        reduceReaderRights(db);
        changeDefaultPerspective(db);
    }

    @Override
    public void onUpdate(OrienteerWebApplication app, ODatabaseSession db, int oldVersion, int newVersion) {
        // Ahora onUpdate puede tener su propia implementación sin afectar a onInstall
        // Por ejemplo, podríamos querer hacer algo diferente si la versión ha cambiado
        if (oldVersion != newVersion) {
            // Hacer algo específico para la actualización
        } else {
            onInstall(app, db);
        }
    }

    // ... el resto del código ...
}
En este ejemplo, onUpdate puede tener su propia implementación sin afectar a onInstall. Si en el futuro necesitamos cambiar la forma en que se maneja la actualización, podemos hacerlo sin modificar el método onInstall. Esto hace que nuestro código sea más flexible y fácil de mantener, cumpliendo con el principio OCP.
![image](https://github.com/OrienteerBAP/OPoster/assets/117050687/60f4f6f1-f75a-4907-ad49-bd7d242fc834)
